### PR TITLE
feat(security): PrincipalDetails 추가

### DIFF
--- a/backend/src/main/java/skkuchin/service/api/controller/ReviewController.java
+++ b/backend/src/main/java/skkuchin/service/api/controller/ReviewController.java
@@ -1,0 +1,37 @@
+package skkuchin.service.api.controller;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.userdetails.User;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import skkuchin.service.api.dto.CMRespDto;
+import skkuchin.service.api.dto.ReviewDto;
+import skkuchin.service.domain.User.AppUser;
+import skkuchin.service.security.auth.PrincipalDetails;
+import skkuchin.service.service.ReviewService;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/review")
+@Slf4j
+public class ReviewController {
+
+    private final ReviewService reviewService;
+
+    @PostMapping("")
+    public ResponseEntity<?> write(@RequestBody ReviewDto dto, Authentication authentication) {
+        PrincipalDetails PrincipalDetails = (PrincipalDetails) authentication.getPrincipal();
+        AppUser user = PrincipalDetails.getUser();
+        //reviewService.write(user, dto);
+        return new ResponseEntity<>(new CMRespDto<>(1, "리뷰 작성 완료", null), HttpStatus.OK);
+    }
+
+}

--- a/backend/src/main/java/skkuchin/service/api/dto/CMRespDto.java
+++ b/backend/src/main/java/skkuchin/service/api/dto/CMRespDto.java
@@ -1,0 +1,14 @@
+package skkuchin.service.api.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@AllArgsConstructor
+@NoArgsConstructor
+@Data
+public class CMRespDto<T> {
+    private int code;
+    private String message;
+    private T data;
+}

--- a/backend/src/main/java/skkuchin/service/api/dto/ReviewDto.java
+++ b/backend/src/main/java/skkuchin/service/api/dto/ReviewDto.java
@@ -1,0 +1,12 @@
+package skkuchin.service.api.dto;
+
+import lombok.Data;
+
+@Data
+public class ReviewDto {
+    private long reviewId;
+    //private long placeId;
+    private float rate;
+    private String content;
+    private String image;
+}

--- a/backend/src/main/java/skkuchin/service/domain/Place/Review.java
+++ b/backend/src/main/java/skkuchin/service/domain/Place/Review.java
@@ -1,0 +1,48 @@
+package skkuchin.service.domain.Place;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import skkuchin.service.domain.User.AppUser;
+
+import javax.persistence.*;
+import javax.validation.constraints.NotNull;
+import javax.validation.constraints.Size;
+import java.time.LocalDateTime;
+
+@Data
+@Entity
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class Review {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @NotNull
+    private float rate;
+
+    @NotNull
+    @Size(min = 1) //리뷰 최대 글자 수 나중에 추가
+    private String content;
+
+    private String image;
+
+    //@JoinColumn(name = "place_id")
+    //@ManyToOne
+    //private Place place;
+
+    @JoinColumn(name = "user_id")
+    @ManyToOne
+    private AppUser user;
+
+    @Column(name = "created_date")
+    private LocalDateTime createdDate;
+
+    @PrePersist
+    public void createDate() {
+        this.createdDate = LocalDateTime.now();
+    }
+}

--- a/backend/src/main/java/skkuchin/service/filter/CustomAuthenticationFilter.java
+++ b/backend/src/main/java/skkuchin/service/filter/CustomAuthenticationFilter.java
@@ -14,6 +14,7 @@ import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.userdetails.User;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 import org.springframework.util.StreamUtils;
+import skkuchin.service.security.auth.PrincipalDetails;
 
 import javax.servlet.FilterChain;
 import javax.servlet.ServletException;
@@ -77,7 +78,8 @@ public class CustomAuthenticationFilter extends UsernamePasswordAuthenticationFi
 
     @Override
     protected void successfulAuthentication(HttpServletRequest request, HttpServletResponse response, FilterChain chain, Authentication authentication) throws IOException, ServletException {
-        User user = (User)authentication.getPrincipal();
+        //User user = (User)authentication.getPrincipal();
+        PrincipalDetails user = (PrincipalDetails) authentication.getPrincipal();
         Algorithm algorithm = Algorithm.HMAC256("secret".getBytes());
         String access_token = JWT.create()
                 .withSubject(user.getUsername())

--- a/backend/src/main/java/skkuchin/service/repo/ReviewRepo.java
+++ b/backend/src/main/java/skkuchin/service/repo/ReviewRepo.java
@@ -1,0 +1,7 @@
+package skkuchin.service.repo;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import skkuchin.service.domain.Place.Review;
+
+public interface ReviewRepo extends JpaRepository<Review, Long> {
+}

--- a/backend/src/main/java/skkuchin/service/security/SecurityConfig.java
+++ b/backend/src/main/java/skkuchin/service/security/SecurityConfig.java
@@ -1,6 +1,7 @@
 package skkuchin.service.security;
 
 import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.http.HttpMethod;
@@ -11,6 +12,7 @@ import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configuration.WebSecurityConfiguration;
 import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
 import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
@@ -19,20 +21,16 @@ import org.springframework.security.web.authentication.UsernamePasswordAuthentic
 import org.springframework.security.web.csrf.CookieCsrfTokenRepository;
 import skkuchin.service.filter.CustomAuthenticationFilter;
 import skkuchin.service.filter.CustomAuthorizationFilter;
+import skkuchin.service.repo.UserRepo;
 
 import static java.lang.invoke.VarHandle.AccessMode.GET;
 import static org.springframework.security.config.http.SessionCreationPolicy.STATELESS;
 
 @Configuration @EnableWebSecurity @RequiredArgsConstructor
 public class SecurityConfig {
-    private final UserDetailsService userDetailsService;
-    //private final BCryptPasswordEncoder bCryptPasswordEncoder; //ServiceApplication.java에 Bean으로 등록되어 있음.
-    private final AuthenticationConfiguration authenticationConfiguration;
-
+    private final UserRepo userRepo;
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
-        CustomAuthenticationFilter customAuthenticationFilter = new CustomAuthenticationFilter(authenticationManager());
-        customAuthenticationFilter.setFilterProcessesUrl("/api/login");
 
 //        http.csrf().csrfTokenRepository(CookieCsrfTokenRepository.withHttpOnlyFalse());
         http.csrf().disable();
@@ -41,15 +39,20 @@ public class SecurityConfig {
         http.authorizeRequests().antMatchers(HttpMethod.GET, "/api/user/**").hasAnyAuthority("ROLE_USER");
         http.authorizeRequests().antMatchers(HttpMethod.POST, "/api/user/save/**").hasAnyAuthority("ROLE_ADMIN");
         http.authorizeRequests().anyRequest().authenticated();
-        http.addFilter(customAuthenticationFilter);
-        http.addFilterBefore(new CustomAuthorizationFilter(), UsernamePasswordAuthenticationFilter.class);
+        http.apply(new MyCustomDsl());
 
         return http.build();
     }
 
-    @Bean
-    public AuthenticationManager authenticationManager() throws Exception{
-        return authenticationConfiguration.getAuthenticationManager();
+    public class MyCustomDsl extends AbstractHttpConfigurer<MyCustomDsl, HttpSecurity> {
+        @Override
+        public void configure(HttpSecurity builder) throws Exception {
+            AuthenticationManager authenticationManager = builder.getSharedObject(AuthenticationManager.class);
+            CustomAuthenticationFilter authenticationFilter = new CustomAuthenticationFilter(authenticationManager);
+            authenticationFilter.setFilterProcessesUrl("/api/login");
+            builder
+                    .addFilter(authenticationFilter)
+                    .addFilterBefore(new CustomAuthorizationFilter(userRepo), UsernamePasswordAuthenticationFilter.class);
+        }
     }
-
 }

--- a/backend/src/main/java/skkuchin/service/security/auth/PrincipalDetails.java
+++ b/backend/src/main/java/skkuchin/service/security/auth/PrincipalDetails.java
@@ -1,0 +1,56 @@
+package skkuchin.service.security.auth;
+
+import lombok.Data;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+import skkuchin.service.domain.User.AppUser;
+
+import java.util.ArrayList;
+import java.util.Collection;
+
+@Data
+public class PrincipalDetails implements UserDetails {
+
+    private AppUser user;
+
+    public PrincipalDetails(AppUser user) { this.user = user; }
+
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        Collection<GrantedAuthority> authorities = new ArrayList<GrantedAuthority>();
+        authorities.add(() -> {
+            return "" + user.getRoles();
+        });
+        return authorities;
+    }
+
+    @Override
+    public String getPassword() {
+        return user.getPassword();
+    }
+
+    @Override
+    public String getUsername() {
+        return user.getUsername();
+    }
+
+    @Override
+    public boolean isAccountNonExpired() {
+        return true;
+    }
+
+    @Override
+    public boolean isAccountNonLocked() {
+        return true;
+    }
+
+    @Override
+    public boolean isCredentialsNonExpired() {
+        return true;
+    }
+
+    @Override
+    public boolean isEnabled() {
+        return true;
+    }
+}

--- a/backend/src/main/java/skkuchin/service/security/auth/PrincipalDetailsService.java
+++ b/backend/src/main/java/skkuchin/service/security/auth/PrincipalDetailsService.java
@@ -1,0 +1,33 @@
+package skkuchin.service.security.auth;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.annotation.Primary;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.stereotype.Service;
+import skkuchin.service.domain.User.AppUser;
+import skkuchin.service.exception.EmailNotAuthenticatedException;
+import skkuchin.service.repo.UserRepo;
+
+import java.util.ArrayList;
+import java.util.Collection;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class PrincipalDetailsService implements UserDetailsService {
+
+    private final UserRepo userRepo;
+
+
+
+    @Override
+    public UserDetails loadUserByUsername(String username) throws UsernameNotFoundException {
+        AppUser user = userRepo.findByUsername(username);
+        return new PrincipalDetails(user);
+    }
+
+}

--- a/backend/src/main/java/skkuchin/service/service/ReviewService.java
+++ b/backend/src/main/java/skkuchin/service/service/ReviewService.java
@@ -1,0 +1,33 @@
+package skkuchin.service.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import skkuchin.service.api.dto.ReviewDto;
+import skkuchin.service.domain.Place.Review;
+import skkuchin.service.domain.User.AppUser;
+import skkuchin.service.repo.ReviewRepo;
+
+import javax.transaction.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class ReviewService {
+
+    private final ReviewRepo reviewRepo;
+
+    @Transactional
+    public void write(AppUser user, ReviewDto dto) {
+
+        //place 관련 코드
+
+        /*
+        Review review = Review.builder()
+                .content(dto.getContent())
+                .rate(dto.getRate())
+                .image(dto.getImage())
+                .user(user)
+                .build();*/
+
+        //reviewRepo.save(review);
+    }
+}

--- a/backend/src/main/java/skkuchin/service/service/UserServiceImpl.java
+++ b/backend/src/main/java/skkuchin/service/service/UserServiceImpl.java
@@ -2,6 +2,7 @@ package skkuchin.service.service;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.annotation.Primary;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.core.userdetails.UserDetailsService;
@@ -21,6 +22,7 @@ import skkuchin.service.mail.EmailAuthRepo;
 import skkuchin.service.mail.EmailService;
 import skkuchin.service.repo.RoleRepo;
 import skkuchin.service.repo.UserRepo;
+import skkuchin.service.security.auth.PrincipalDetails;
 
 import javax.mail.MessagingException;
 import javax.transaction.Transactional;
@@ -31,7 +33,7 @@ import java.util.Collection;
 import java.util.List;
 
 @Service @RequiredArgsConstructor @Transactional @Slf4j
-public class UserServiceImpl implements UserService, UserDetailsService {
+public class UserServiceImpl implements UserService {
     private final UserRepo userRepo;
     private final RoleRepo roleRepo;
     private final EmailAuthRepo emailAuthRepo;
@@ -44,26 +46,6 @@ public class UserServiceImpl implements UserService, UserDetailsService {
         if (existingUser == null) {
             return false;
         } else return true;
-    }
-
-    @Override
-    public UserDetails loadUserByUsername(String username) throws UsernameNotFoundException {
-
-        AppUser user = userRepo.findByUsername(username);
-        if (user == null) {
-            log.info("User not found in the database");
-            throw new UsernameNotFoundException("User not found in the database");
-        } else {
-            log.info("User found in the database: {}", username);
-        }
-        if (!user.getEmailAuth()) {
-            throw new EmailNotAuthenticatedException("email_auth_error");
-        }
-        Collection<SimpleGrantedAuthority> authorities = new ArrayList<>();
-        user.getRoles().forEach(role -> {
-            authorities.add(new SimpleGrantedAuthority(role.getName()));
-        });
-        return new org.springframework.security.core.userdetails.User(user.getUsername(), user.getPassword(), authorities);
     }
 
     @Override

--- a/backend/src/test/java/skkuchin/service/service/UserServiceTest.java
+++ b/backend/src/test/java/skkuchin/service/service/UserServiceTest.java
@@ -51,30 +51,6 @@ public class UserServiceTest extends MockTest {
     }
 
     @Test
-    public void username으로_user_불러오기_성공() {
-        //given
-        Collection<Role> roles = new ArrayList<>();
-        roles.add(new Role(1L, "ROLE_USER"));
-        AppUser user = new AppUser(1L, "user", "user111", "1234", "dlaudwns789@gmail.com", "2016310372", Major.글로벌경영학과, "이미지", Mbti.ENFP, LocalDateTime.now(), roles, true);
-        given(userRepo.findByUsername(any())).willReturn(user);
-
-        //when
-        UserDetails test = userService.loadUserByUsername("user");
-
-        //then
-        assertThat(test).isNotNull();
-    }
-
-    @Test(expected = UsernameNotFoundException.class)
-    public void username으로_user_불러오기_실패() {
-        //given
-        given(userRepo.findByUsername("user2")).willReturn(null);
-
-        //when
-        UserDetails test = userService.loadUserByUsername("user2");
-    }
-
-    @Test
     public void saveUser_성공() throws MessagingException, UnsupportedEncodingException {
         //given
         Collection<Role> roles = new ArrayList<>();


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! -->
<!-- * are required. -->


#### Notion Task Number *
<!-- Copy the Notion Task Number. e.g. 167220840-P-SYHJ -->
167263218-B-YJ

#### Assignee *
<!-- Github Username. e.g. myungjunlee -->
syj0396

#### PR Summary *
<!-- A short description of what this pull request does. e.g. 새로운 페이지 진입 시, 스크립트 에러 버그 수정 PR입니다 -->
controller나 service에서 AppUser object를 불러오고 싶을 때, 매번 userRepo와 연결하지 않고 token만 사용해서 불러올 수 있도록 PrincipalDetails를 추가했습니다
config나 filter도 약간의 수정 사항 있습니다

#### Screenshots / GIFs / Videos
<!-- If the PR includes changes, please include screenshots/GIFs/videos for the team and reviewers. -->
- **AS-IS**

- **TO-BE**


#### Additional Comments
<!-- Add any additional information or comments that would be helpful to the team or reviewers. e.g. 기획서 첨부, 레퍼런스 링크 -->

