### PR TITLE
테이블 명, 변수 타입 변경 및 candidate 테스트 코드 작성 완료했습니다.

### DIFF
--- a/backend/src/main/java/skkuchin/service/ServiceApplication.java
+++ b/backend/src/main/java/skkuchin/service/ServiceApplication.java
@@ -39,10 +39,10 @@ public class ServiceApplication {
 			userService.saveRole(new Role(null, "ROLE_ADMIN"));
 
 			//admin 계정 생성
-			userService.saveAdmin(new UserDto.SignUpForm("스꾸친관리자", "admin", "12341234", "12341234", "test@test", "0000000000", Major.건축학과));
+			userService.saveAdmin(new UserDto.SignUpForm("스꾸친관리자", "admin", "12341234", "12341234", "test@test", 16, Major.건축학과));
 
 			//test 계정 생성
-			userService.saveTestUser(new UserDto.SignUpForm("테스트", "test", "12341234", "12341234", "test1@test1", "0000000001", Major.건축학과));
+			userService.saveTestUser(new UserDto.SignUpForm("테스트", "test", "12341234", "12341234", "test1@test1", 20, Major.건축학과));
 			//데이터 자동 주입
 			//String path = System.getProperty("user.dir") + "\\src\\main\\java\\skkuchin\\service\\data\\";
 			String path = System.getProperty("user.dir") + "/src/main/java/skkuchin/service/data/"; //Mac 공통 경로

--- a/backend/src/main/java/skkuchin/service/api/dto/CandidateDto.java
+++ b/backend/src/main/java/skkuchin/service/api/dto/CandidateDto.java
@@ -52,7 +52,8 @@ public class CandidateDto {
         private String image;
         private Major major;
         @JsonProperty
-        private String studentId;
+        //private String studentId;
+        private int studentId;
         private Mbti mbti;
         private List<String> keywords;
         private String introduction;

--- a/backend/src/main/java/skkuchin/service/api/dto/MatchingUserDto.java
+++ b/backend/src/main/java/skkuchin/service/api/dto/MatchingUserDto.java
@@ -63,7 +63,8 @@ public class MatchingUserDto {
         private String image;
         private Major major;
         @JsonProperty
-        private String studentId;
+        //private String studentId;
+        private int studentId;
         private Mbti mbti;
         private Boolean matching;
         private List<String> keywords;

--- a/backend/src/main/java/skkuchin/service/api/dto/ReviewDto.java
+++ b/backend/src/main/java/skkuchin/service/api/dto/ReviewDto.java
@@ -82,7 +82,8 @@ public class ReviewDto {
         private String nickname;
         private Major major;
         @JsonProperty
-        private String studentId;
+        //private String studentId;
+        private int studentId;
         @JsonProperty
         private String userImage;
         private List<String> tags;

--- a/backend/src/main/java/skkuchin/service/api/dto/UserDto.java
+++ b/backend/src/main/java/skkuchin/service/api/dto/UserDto.java
@@ -11,9 +11,7 @@ import skkuchin.service.domain.Matching.Keyword;
 import skkuchin.service.domain.Matching.UserKeyword;
 import skkuchin.service.domain.User.*;
 
-import javax.validation.constraints.NotBlank;
-import javax.validation.constraints.NotNull;
-import javax.validation.constraints.Size;
+import javax.validation.constraints.*;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
@@ -35,9 +33,11 @@ public class UserDto {
         private String rePassword;
         @NotBlank
         private String email;
-        @NotBlank
+        @NotNull
         @JsonProperty
-        private String studentId;
+        @Min(value = 10)
+        @Max(value = 23)
+        private int studentId;
         @NotNull
         private Major major;
 
@@ -82,7 +82,8 @@ public class UserDto {
         private String username;
         private String email;
         @JsonProperty
-        private String studentId;
+        //private String studentId;
+        private int studentId;
         private Major major;
         private String image;
         private Mbti mbti;

--- a/backend/src/main/java/skkuchin/service/domain/User/AppUser.java
+++ b/backend/src/main/java/skkuchin/service/domain/User/AppUser.java
@@ -17,6 +17,7 @@ import java.util.List;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
 @Builder
+@Table(name = "user")
 public class AppUser {
     @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
@@ -33,8 +34,8 @@ public class AppUser {
     @Column(unique = true, nullable = false)
     private String email;
 
-    @Column(unique = true, nullable = false)
-    private String studentId;
+    @Column(nullable = false)
+    private int studentId;
 
     @Column(nullable = false)
     @Enumerated(EnumType.STRING)

--- a/backend/src/test/java/skkuchin/service/config/CandidateSetUp.java
+++ b/backend/src/test/java/skkuchin/service/config/CandidateSetUp.java
@@ -1,0 +1,55 @@
+package skkuchin.service.config;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+import skkuchin.service.api.dto.CandidateDto;
+import skkuchin.service.domain.Matching.Candidate;
+import skkuchin.service.domain.Matching.Keyword;
+import skkuchin.service.domain.Matching.UserKeyword;
+import skkuchin.service.domain.User.AppUser;
+import skkuchin.service.repo.CandidateRepo;
+import skkuchin.service.repo.KeywordRepo;
+import skkuchin.service.repo.UserKeywordRepo;
+import skkuchin.service.repo.UserRepo;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Component
+public class CandidateSetUp {
+    @Autowired
+    private CandidateRepo candidateRepo;
+    @Autowired
+    private UserKeywordRepo userKeywordRepo;
+    @Autowired
+    private KeywordRepo keywordRepo;
+
+    public void saveCandidate(AppUser user, AppUser user1, AppUser user2, AppUser user3) {
+        Candidate candidate = Candidate.builder()
+                .user(user)
+                .candidate1(user1)
+                .candidate2(user2)
+                .candidate3(user3)
+                .build();
+        candidateRepo.save(candidate);
+    }
+
+    public void saveCandidateExpireDate(AppUser user, AppUser user1, LocalDateTime date) {
+        Candidate candidate = Candidate.builder()
+                .user(user)
+                .candidate1(user1)
+                .expireDate(date)
+                .build();
+    }
+
+    public void saveUserKeyword(AppUser user, List<String> keywords) {
+        List<UserKeyword> userKeywords = keywords.stream()
+                .map(k -> {
+                    Keyword keyword = keywordRepo.findByName(k);
+                    return UserKeyword.builder().keyword(keyword).user(user).build();
+                })
+                .collect(Collectors.toList());
+        userKeywordRepo.saveAll(userKeywords);
+    }
+}

--- a/backend/src/test/java/skkuchin/service/config/UserSetUp.java
+++ b/backend/src/test/java/skkuchin/service/config/UserSetUp.java
@@ -17,7 +17,7 @@ public class UserSetUp {
     private UserRepo userRepo;
 
 
-    public Long saveUser(String nickname, String username, String password, String email, String student_id, Major major, String image, Mbti mbti, Collection<Role> roles) {
+    public Long saveUser(String nickname, String username, String password, String email, int student_id, Major major, String image, Mbti mbti, Collection<Role> roles) {
         AppUser user = AppUser.builder()
                 .nickname(nickname)
                 .username(username)

--- a/backend/src/test/java/skkuchin/service/integration/CandidateIntegrationTest.java
+++ b/backend/src/test/java/skkuchin/service/integration/CandidateIntegrationTest.java
@@ -1,0 +1,333 @@
+package skkuchin.service.integration;
+
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.PropertyAccessor;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.jayway.jsonpath.JsonPath;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.MediaType;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.web.servlet.MvcResult;
+import org.springframework.test.web.servlet.ResultActions;
+import skkuchin.service.api.dto.CandidateDto;
+import skkuchin.service.common.BaseIntegrationTest;
+import skkuchin.service.config.CandidateSetUp;
+import skkuchin.service.domain.User.AppUser;
+import skkuchin.service.domain.User.Major;
+import skkuchin.service.domain.User.Role;
+import skkuchin.service.repo.UserRepo;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+public class CandidateIntegrationTest extends BaseIntegrationTest {
+
+    @Autowired
+    CandidateSetUp candidateSetUp;
+    @Autowired
+    UserRepo userRepo;
+    @Autowired
+    private PasswordEncoder passwordEncoder;
+
+
+    @Test
+    public void 후보_3명_모두_1순위_같은학과_우선() throws Exception {
+        //given
+        Collection<Role> roles = new ArrayList<>();
+        roles.add(new Role(1L, "ROLE_USER"));
+        AppUser user = AppUser.builder().nickname("user").username("user").major(Major.건축학과).matching(true).email("test").password(passwordEncoder.encode("1234")).studentId(20).roles(roles).build();
+        List<String> keywords = List.of("한식", "일식", "동아리");
+
+        //이미 후보에 올랐던 유저
+        AppUser existing1 = AppUser.builder().nickname("existing1").username("user2").major(Major.건축학과).email("test2").password("1234").studentId(20).build();
+        List<String> existingKeywords1 = List.of("한식", "일식", "동아리");
+        AppUser existing2 = AppUser.builder().nickname("existing2").username("user3").major(Major.건축학과).email("test3").password("1234").studentId(20).build();
+        List<String> existingKeywords2 = List.of("한식", "일식", "동아리");
+        AppUser existing3 = AppUser.builder().nickname("existing3").username("user4").major(Major.건축학과).email("test4").password("1234").studentId(20).build();
+        List<String> existingKeywords3 = List.of("한식", "일식", "동아리");
+
+        //후보에 오를 유저 (최종 출력 순서는 new2, new1, new3)
+        AppUser new1 = AppUser.builder().nickname("new1").username("user5").major(Major.글로벌경영학과).matching(true).email("test5").password("1234").studentId(20).build();
+        List<String> keywords1 = List.of("한식", "일식", "동아리");
+        AppUser new2 = AppUser.builder().nickname("new2").username("user6").major(Major.건축학과).matching(true).email("test6").password("1234").studentId(20).build();
+        List<String> keywords2 = List.of("한식", "일식", "동아리");
+        AppUser new3 = AppUser.builder().nickname("new3").username("user7").major(Major.건설환경공학부).matching(true).email("test7").password("1234").studentId(20).build();
+        List<String> keywords3 = List.of("한식", "일식", "축구");
+
+        userRepo.saveAll(List.of(user, existing1, existing2, existing3, new1, new2, new3));
+        candidateSetUp.saveUserKeyword(user, keywords);
+        candidateSetUp.saveCandidate(user, existing1, existing2, existing3);
+        candidateSetUp.saveUserKeyword(existing1, existingKeywords1);
+        candidateSetUp.saveUserKeyword(existing2, existingKeywords2);
+        candidateSetUp.saveUserKeyword(existing3, existingKeywords3);
+        candidateSetUp.saveUserKeyword(new1, keywords1);
+        candidateSetUp.saveUserKeyword(new2, keywords2);
+        candidateSetUp.saveUserKeyword(new3, keywords3);
+
+        objectMapper.setVisibility(PropertyAccessor.FIELD, JsonAutoDetect.Visibility.ANY);
+        String token = getToken("user", "1234");
+
+        //when
+        ResultActions resultActions = mvc.perform(get("/api/candidate")
+                        .header("Authorization", token)
+                        .accept(MediaType.APPLICATION_JSON))
+                .andDo(print());
+
+        //then
+        resultActions
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$..data[0].nickname", String.class).value("new2"))
+                .andExpect(jsonPath("$..data[1].nickname", String.class).value("new1"))
+                .andExpect(jsonPath("$..data[2].nickname", String.class).value("new3"));
+
+    }
+
+    @Test
+    public void 후보_1명은_1순위_2명은_2순위_같은학과_우선() throws Exception {
+        //given
+        Collection<Role> roles = new ArrayList<>();
+        roles.add(new Role(1L, "ROLE_USER"));
+        AppUser user = AppUser.builder().nickname("user").username("user").major(Major.건축학과).matching(true).email("test").password(passwordEncoder.encode("1234")).studentId(20).roles(roles).build();
+        List<String> keywords = List.of("한식", "일식", "동아리");
+
+        //이미 후보에 올랐던 유저
+        AppUser existing1 = AppUser.builder().nickname("existing1").username("user2").major(Major.건축학과).email("test2").password("1234").studentId(20).build();
+        List<String> existingKeywords1 = List.of("한식", "일식", "동아리");
+        AppUser existing2 = AppUser.builder().nickname("existing2").username("user3").major(Major.건축학과).email("test3").password("1234").studentId(20).build();
+        List<String> existingKeywords2 = List.of("한식", "일식", "동아리");
+        AppUser existing3 = AppUser.builder().nickname("existing3").username("user4").major(Major.건축학과).email("test4").password("1234").studentId(20).build();
+        List<String> existingKeywords3 = List.of("한식", "일식", "동아리");
+
+        //후보에 오를 유저 (최종 출력 순서는 new2, new3, new1)
+        AppUser new1 = AppUser.builder().nickname("new1").username("user5").major(Major.글로벌경영학과).matching(true).email("test5").password("1234").studentId(20).build();
+        List<String> keywords1 = List.of("양식", "축구", "학회");
+        AppUser new2 = AppUser.builder().nickname("new2").username("user6").major(Major.건축학과).matching(true).email("test6").password("1234").studentId(20).build();
+        List<String> keywords2 = List.of("한식", "일식", "동아리");
+        AppUser new3 = AppUser.builder().nickname("new3").username("user7").major(Major.건축학과).matching(true).email("test7").password("1234").studentId(20).build();
+        List<String> keywords3 = List.of("양식", "축구", "학회");
+
+        userRepo.saveAll(List.of(user, existing1, existing2, existing3, new1, new2, new3));
+        candidateSetUp.saveUserKeyword(user, keywords);
+        candidateSetUp.saveCandidate(user, existing1, existing2, existing3);
+        candidateSetUp.saveUserKeyword(existing1, existingKeywords1);
+        candidateSetUp.saveUserKeyword(existing2, existingKeywords2);
+        candidateSetUp.saveUserKeyword(existing3, existingKeywords3);
+        candidateSetUp.saveUserKeyword(new1, keywords1);
+        candidateSetUp.saveUserKeyword(new2, keywords2);
+        candidateSetUp.saveUserKeyword(new3, keywords3);
+
+        objectMapper.setVisibility(PropertyAccessor.FIELD, JsonAutoDetect.Visibility.ANY);
+        String token = getToken("user", "1234");
+
+        //when
+        ResultActions resultActions = mvc.perform(get("/api/candidate")
+                        .header("Authorization", token)
+                        .accept(MediaType.APPLICATION_JSON))
+                .andDo(print());
+
+        //then
+        resultActions
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$..data[0].nickname", String.class).value("new2"))
+                .andExpect(jsonPath("$..data[1].nickname", String.class).value("new3"))
+                .andExpect(jsonPath("$..data[2].nickname", String.class).value("new1"));
+    }
+
+    @Test
+    public void 후보_1명_2순위_2명_3순위_같은학과_우선() throws Exception {
+        //given
+        Collection<Role> roles = new ArrayList<>();
+        roles.add(new Role(1L, "ROLE_USER"));
+        AppUser user = AppUser.builder().nickname("user").username("user").major(Major.건축학과).matching(true).email("test").password(passwordEncoder.encode("1234")).studentId(20).roles(roles).build();
+        List<String> keywords = List.of("한식", "일식", "동아리");
+
+        //이미 후보에 올랐던 유저
+        AppUser existing1 = AppUser.builder().nickname("existing1").username("user2").major(Major.건축학과).email("test2").password("1234").studentId(20).build();
+        List<String> existingKeywords1 = List.of("한식", "일식", "동아리");
+        AppUser existing2 = AppUser.builder().nickname("existing2").username("user3").major(Major.건축학과).email("test3").password("1234").studentId(20).build();
+        List<String> existingKeywords2 = List.of("한식", "일식", "동아리");
+        AppUser existing3 = AppUser.builder().nickname("existing3").username("user4").major(Major.건축학과).email("test4").password("1234").studentId(20).build();
+        List<String> existingKeywords3 = List.of("한식", "일식", "동아리");
+
+        //후보에 오를 유저 (최종 출력 순서는 new2, new3, new1)
+        AppUser new1 = AppUser.builder().nickname("new1").username("user5").major(Major.글로벌경영학과).matching(true).email("test5").password("1234").studentId(20).build();
+        List<String> keywords1 = List.of("볼링", "댄스", "영화");
+        AppUser new2 = AppUser.builder().nickname("new2").username("user6").major(Major.건축학과).matching(true).email("test6").password("1234").studentId(20).build();
+        List<String> keywords2 = List.of("양식", "축구", "학회");
+        AppUser new3 = AppUser.builder().nickname("new3").username("user7").major(Major.건축학과).matching(true).email("test7").password("1234").studentId(20).build();
+        List<String> keywords3 = List.of("볼링", "댄스", "영화");
+
+        userRepo.saveAll(List.of(user, existing1, existing2, existing3, new1, new2, new3));
+        candidateSetUp.saveUserKeyword(user, keywords);
+        candidateSetUp.saveCandidate(user, existing1, existing2, existing3);
+        candidateSetUp.saveUserKeyword(existing1, existingKeywords1);
+        candidateSetUp.saveUserKeyword(existing2, existingKeywords2);
+        candidateSetUp.saveUserKeyword(existing3, existingKeywords3);
+        candidateSetUp.saveUserKeyword(new1, keywords1);
+        candidateSetUp.saveUserKeyword(new2, keywords2);
+        candidateSetUp.saveUserKeyword(new3, keywords3);
+
+        objectMapper.setVisibility(PropertyAccessor.FIELD, JsonAutoDetect.Visibility.ANY);
+        String token = getToken("user", "1234");
+
+        //when
+        ResultActions resultActions = mvc.perform(get("/api/candidate")
+                        .header("Authorization", token)
+                        .accept(MediaType.APPLICATION_JSON))
+                .andDo(print());
+
+        //then
+        resultActions
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$..data[0].nickname", String.class).value("new2"))
+                .andExpect(jsonPath("$..data[1].nickname", String.class).value("new3"))
+                .andExpect(jsonPath("$..data[2].nickname", String.class).value("new1"));
+    }
+
+    @Test
+    public void _3순위_후보_3명_미만() throws Exception {
+        //given
+        Collection<Role> roles = new ArrayList<>();
+        roles.add(new Role(1L, "ROLE_USER"));
+        AppUser user = AppUser.builder().nickname("user").username("user").major(Major.건축학과).matching(true).email("test").password(passwordEncoder.encode("1234")).studentId(20).roles(roles).build();
+        List<String> keywords = List.of("한식", "일식", "동아리");
+
+        //이미 후보에 올랐던 유저
+        AppUser existing1 = AppUser.builder().nickname("existing1").username("user2").major(Major.건축학과).email("test2").password("1234").studentId(20).build();
+        List<String> existingKeywords1 = List.of("한식", "일식", "동아리");
+        AppUser existing2 = AppUser.builder().nickname("existing2").username("user3").major(Major.건축학과).email("test3").password("1234").studentId(20).build();
+        List<String> existingKeywords2 = List.of("한식", "일식", "동아리");
+        AppUser existing3 = AppUser.builder().nickname("existing3").username("user4").major(Major.건축학과).email("test4").password("1234").studentId(20).build();
+        List<String> existingKeywords3 = List.of("한식", "일식", "동아리");
+
+        //후보에 오를 유저
+        AppUser new1 = AppUser.builder().nickname("new1").username("user5").major(Major.글로벌경영학과).matching(true).email("test5").password("1234").studentId(20).build();
+        List<String> keywords1 = List.of("볼링", "축구", "영화");
+        AppUser new2 = AppUser.builder().nickname("new2").username("user6").major(Major.건축학과).matching(true).email("test6").password("1234").studentId(20).build();
+        List<String> keywords2 = List.of("볼링", "축구", "영화");
+
+        userRepo.saveAll(List.of(user, existing1, existing2, existing3, new1, new2));
+        candidateSetUp.saveUserKeyword(user, keywords);
+        candidateSetUp.saveCandidate(user, existing1, existing2, existing3);
+        candidateSetUp.saveUserKeyword(existing1, existingKeywords1);
+        candidateSetUp.saveUserKeyword(existing2, existingKeywords2);
+        candidateSetUp.saveUserKeyword(existing3, existingKeywords3);
+        candidateSetUp.saveUserKeyword(new1, keywords1);
+        candidateSetUp.saveUserKeyword(new2, keywords2);
+
+        objectMapper.setVisibility(PropertyAccessor.FIELD, JsonAutoDetect.Visibility.ANY);
+        String token = getToken("user", "1234");
+
+        //when
+        ResultActions resultActions = mvc.perform(get("/api/candidate")
+                        .header("Authorization", token)
+                        .accept(MediaType.APPLICATION_JSON))
+                .andDo(print());
+
+        //then
+        resultActions
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$..data.length()", equalTo(2)))
+                .andExpect(jsonPath("$..data[0].nickname", String.class).value("new2"))
+                .andExpect(jsonPath("$..data[1].nickname", String.class).value("new1"));
+    }
+
+    @Test
+    public void 일반_유저가_candidate추가_시도_에러() throws Exception {
+        Collection<Role> roles = new ArrayList<>();
+        roles.add(new Role(1L, "ROLE_USER"));
+        AppUser user = AppUser.builder().nickname("user").username("user").major(Major.건축학과).matching(true).email("test").password(passwordEncoder.encode("1234")).studentId(20).roles(roles).build();
+        AppUser user2 = AppUser.builder().nickname("user2").username("user2").major(Major.건축학과).matching(true).email("test2").password(passwordEncoder.encode("1234")).studentId(20).roles(roles).build();
+        userRepo.saveAll(List.of(user, user2));
+
+        CandidateDto.PostRequest dto = new CandidateDto.PostRequest(user.getId(), user2.getId(), null, null);
+        objectMapper.setVisibility(PropertyAccessor.FIELD, JsonAutoDetect.Visibility.ANY);
+        String form = objectMapper.writeValueAsString(dto);
+        String token = getToken("test", "12341234");
+
+        //when
+        ResultActions resultActions = mvc.perform(post("/api/candidate")
+                        .header("Authorization", token)
+                        .accept(MediaType.APPLICATION_JSON)
+                        .content(form))
+                        .andDo(print());
+
+        //then
+        resultActions
+                .andExpect(status().is4xxClientError());
+    }
+
+    @Test
+    public void 만료기간_지난_candidate_삭제_성공() throws Exception {
+        //given
+        Collection<Role> roles = new ArrayList<>();
+        roles.add(new Role(1L, "ROLE_ADMIN"));
+        AppUser user = AppUser.builder().nickname("user").username("user").major(Major.건축학과).matching(true).email("test").password(passwordEncoder.encode("1234")).studentId(20).roles(roles).build();
+        List<String> keywords = List.of("한식", "일식", "동아리");
+
+        AppUser existing1 = AppUser.builder().nickname("existing1").username("user2").major(Major.건축학과).email("test2").password("1234").studentId(20).build();
+        List<String> existingKeywords1 = List.of("한식", "일식", "동아리");
+        AppUser existing2 = AppUser.builder().nickname("existing2").username("user3").major(Major.건축학과).email("test3").password("1234").studentId(20).build();
+        List<String> existingKeywords2 = List.of("한식", "일식", "동아리");
+
+        userRepo.saveAll(List.of(user, existing1, existing2));
+        candidateSetUp.saveCandidateExpireDate(user, existing1, LocalDateTime.now().minusDays(1));
+        candidateSetUp.saveCandidateExpireDate(user, existing2, LocalDateTime.now().plusDays(1));
+
+        objectMapper.setVisibility(PropertyAccessor.FIELD, JsonAutoDetect.Visibility.ANY);
+        String token = getToken("user", "1234");
+
+        //when
+        ResultActions resultActions = mvc.perform(delete("/api/candidate")
+                        .header("Authorization", token)
+                        .accept(MediaType.APPLICATION_JSON))
+                        .andDo(print());
+
+        //then
+        resultActions
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    public void 일반유저가_candidate_삭제_시도_에러() throws Exception {
+        //given
+        Collection<Role> roles = new ArrayList<>();
+        roles.add(new Role(1L, "ROLE_USER"));
+        AppUser user = AppUser.builder().nickname("user").username("user").major(Major.건축학과).matching(true).email("test").password(passwordEncoder.encode("1234")).studentId(20).roles(roles).build();
+        userRepo.save(user);
+
+        objectMapper.setVisibility(PropertyAccessor.FIELD, JsonAutoDetect.Visibility.ANY);
+        String token = getToken("user", "1234");
+
+        //when
+        ResultActions resultActions = mvc.perform(delete("/api/candidate")
+                        .header("Authorization", token)
+                        .accept(MediaType.APPLICATION_JSON))
+                        .andDo(print());
+
+        //then
+        resultActions
+                .andExpect(status().is4xxClientError());
+    }
+
+    public String getToken(String username, String password) throws Exception {
+        String form = objectMapper.writeValueAsString(new LoginFormTestVer(username, password));
+        MvcResult loginResult = mvc.perform(post("/api/login")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(form)
+                        .accept(MediaType.APPLICATION_JSON))
+                .andReturn();
+
+        return "Bearer " + JsonPath.read(loginResult.getResponse().getContentAsString(), "$.access");
+    }
+}

--- a/backend/src/test/java/skkuchin/service/integration/UserIntegrationTest.java
+++ b/backend/src/test/java/skkuchin/service/integration/UserIntegrationTest.java
@@ -50,8 +50,8 @@ public class UserIntegrationTest extends BaseIntegrationTest {
         //given
         Collection<Role> roles = new ArrayList<>();
         roles.add(new Role(1L, "ROLE_USER"));
-        userSetUp.saveUser("user1", "user111", "1234", "dlaudwns789@gmail.com", "2016310372", Major.글로벌경영학과, "이미지", Mbti.ENFP, roles);
-        userSetUp.saveUser("user2", "user222", "1234", "dlaudwns780@gmail.com", "2016310373", Major.글로벌경영학과, "이미지", Mbti.ENFP, roles);
+        userSetUp.saveUser("user1", "user111", "1234", "dlaudwns789@gmail.com", 16, Major.글로벌경영학과, "이미지", Mbti.ENFP, roles);
+        userSetUp.saveUser("user2", "user222", "1234", "dlaudwns780@gmail.com", 16, Major.글로벌경영학과, "이미지", Mbti.ENFP, roles);
 
         //when
         ResultActions resultActions = mvc.perform(get("/api/users")
@@ -70,7 +70,7 @@ public class UserIntegrationTest extends BaseIntegrationTest {
         //given
         objectMapper.setVisibility(PropertyAccessor.FIELD, JsonAutoDetect.Visibility.ANY); //SignUpForm을 읽어들이기 위함.
         String form = objectMapper.writeValueAsString(
-                new SignUpFormTestVer("user", "user111", "1234", "1234", "dlaudwns789@gmail.com", "2016310372", "글로벌경영학과", "이미지", Mbti.ENFP));
+                new SignUpFormTestVer("user", "user111", "1234", "1234", "dlaudwns789@gmail.com", 16, "글로벌경영학과", "이미지", Mbti.ENFP));
 
         //when
         ResultActions resultActions = mvc.perform(post("/api/user/saves")
@@ -91,7 +91,7 @@ public class UserIntegrationTest extends BaseIntegrationTest {
         //given
         objectMapper.setVisibility(PropertyAccessor.FIELD, JsonAutoDetect.Visibility.ANY);
         String form = objectMapper.writeValueAsString(
-                new SignUpFormTestVer("user", "user111", "124", "1234", "dlaudwns789@gmail.com", "2016310372", "글로벌경영학과", "이미지", Mbti.ENFP));
+                new SignUpFormTestVer("user", "user111", "124", "1234", "dlaudwns789@gmail.com", 16, "글로벌경영학과", "이미지", Mbti.ENFP));
 
         //when
         ResultActions resultActions = mvc.perform(post("/api/user/saves")
@@ -114,13 +114,13 @@ public class UserIntegrationTest extends BaseIntegrationTest {
         //given
         Collection<Role> roles = new ArrayList<>();
         roles.add(new Role(1L, "ROLE_USER"));
-        userSetUp.saveUser("user1", "user111", "1234", "dlaudwns789@gmail.com", "2016310372", Major.글로벌경영학과, "이미지", Mbti.ENFP, roles);
+        userSetUp.saveUser("user1", "user111", "1234", "dlaudwns789@gmail.com", 16, Major.글로벌경영학과, "이미지", Mbti.ENFP, roles);
         //userSetUp.saveUser("user1", "user111", "1234", roles);
         //ConstraintViolationException DataIntegrityViolationException
 
         objectMapper.setVisibility(PropertyAccessor.FIELD, JsonAutoDetect.Visibility.ANY);
         String form = objectMapper.writeValueAsString(
-                new SignUpFormTestVer("user1", "user222", "1234", "1234", "dlaudwns789@gmail.com", "2016310372", "글로벌경영학과", "이미지", Mbti.ENFP));
+                new SignUpFormTestVer("user1", "user222", "1234", "1234", "dlaudwns789@gmail.com", 16, "글로벌경영학과", "이미지", Mbti.ENFP));
 
         //when
         ResultActions resultActions = mvc.perform(post("/api/user/saves")
@@ -143,7 +143,7 @@ public class UserIntegrationTest extends BaseIntegrationTest {
         //given
         Collection<Role> roles = new ArrayList<>();
         String pw = passwordEncoder.encode("1111");
-        userSetUp.saveUser("user1", "user111", pw, "dlaudwns789@gmail.com", "2016310372", Major.글로벌경영학과, "이미지", Mbti.ENFP, roles);
+        userSetUp.saveUser("user1", "user111", pw, "dlaudwns789@gmail.com", 16, Major.글로벌경영학과, "이미지", Mbti.ENFP, roles);
         objectMapper.setVisibility(PropertyAccessor.FIELD, JsonAutoDetect.Visibility.ANY);
         String form = objectMapper.writeValueAsString(new LoginFormTestVer("user111", "1111"));
 
@@ -171,7 +171,7 @@ public class UserIntegrationTest extends BaseIntegrationTest {
         //given
         Collection<Role> roles = new ArrayList<>();
         String pw = passwordEncoder.encode("1111");
-        userSetUp.saveUser("user1", "user111", pw, "dlaudwns789@gmail.com", "2016310372", Major.글로벌경영학과, "이미지", Mbti.ENFP, roles);
+        userSetUp.saveUser("user1", "user111", pw, "dlaudwns789@gmail.com", 16, Major.글로벌경영학과, "이미지", Mbti.ENFP, roles);
         objectMapper.setVisibility(PropertyAccessor.FIELD, JsonAutoDetect.Visibility.ANY);
         String form = objectMapper.writeValueAsString(new LoginFormTestVer("user111", "1111"));
 
@@ -202,7 +202,7 @@ public class UserIntegrationTest extends BaseIntegrationTest {
         Collection<Role> roles = new ArrayList<>();
         roles.add(new Role(1L, "ROLE_USER"));
         String pw = passwordEncoder.encode("1111");
-        userSetUp.saveUser("user1", "user111", pw, "dlaudwns789@gmail.com", "2016310372", Major.글로벌경영학과, "이미지", Mbti.ENFP, roles);
+        userSetUp.saveUser("user1", "user111", pw, "dlaudwns789@gmail.com", 16, Major.글로벌경영학과, "이미지", Mbti.ENFP, roles);
         objectMapper.setVisibility(PropertyAccessor.FIELD, JsonAutoDetect.Visibility.ANY);
         String form = objectMapper.writeValueAsString(new LoginFormTestVer("user111", "1111"));
 
@@ -235,12 +235,12 @@ class SignUpFormTestVer {
     private String password;
     private String re_password;
     private String email;
-    private String student_id;
+    private int student_id;
     private String major;
     private String image;
     private Mbti mbti;
 
-    public SignUpFormTestVer(String nickname, String username, String password, String re_password, String email, String student_id, String major, String image, Mbti mbti) {
+    public SignUpFormTestVer(String nickname, String username, String password, String re_password, String email, int student_id, String major, String image, Mbti mbti) {
         this.nickname = nickname;
         this.username = username;
         this.password = password;

--- a/backend/src/test/java/skkuchin/service/service/CandidateServiceTest.java
+++ b/backend/src/test/java/skkuchin/service/service/CandidateServiceTest.java
@@ -1,0 +1,101 @@
+package skkuchin.service.service;
+
+import org.junit.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import skkuchin.service.api.dto.CandidateDto;
+import skkuchin.service.common.MockTest;
+import skkuchin.service.domain.Matching.Candidate;
+import skkuchin.service.domain.User.AppUser;
+import skkuchin.service.domain.User.Major;
+import skkuchin.service.repo.CandidateRepo;
+import skkuchin.service.repo.UserKeywordRepo;
+import skkuchin.service.repo.UserRepo;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+
+
+public class CandidateServiceTest extends MockTest {
+    @InjectMocks
+    CandidateService candidateService;
+    @Mock
+    CandidateRepo candidateRepo;
+    @Mock
+    UserKeywordRepo userKeywordRepo;
+    @Mock
+    UserRepo userRepo;
+
+
+    @Test
+    public void getCandidate_성공() {
+        //1순위 1명, 2순위 1명, 3순위 1명 -> 모든 함수 테스트
+        //given
+        AppUser user = AppUser.builder().id(1L).nickname("user").major(Major.건축학과).build();
+        AppUser existingUser = AppUser.builder().id(2L).nickname("existingUser").major(Major.경영학과).build();
+        AppUser existingUser2 = AppUser.builder().id(3L).nickname("existingUser2").major(Major.경영학과).build();
+        AppUser newUser = AppUser.builder().id(4L).nickname("newUser").major(Major.경영학과).build();
+        AppUser newUser2 = AppUser.builder().id(5L).nickname("newUser2").major(Major.경영학과).build();
+        AppUser newUser3 = AppUser.builder().id(6L).nickname("newUser3").major(Major.경영학과).build();
+        List<Long> keywordIds = List.of(1L, 2L, 3L);
+        List<String> categoryList = List.of("음식", "운동");
+        Candidate existingCandidate = Candidate.builder().user(user).candidate1(existingUser).candidate2(existingUser2).build();
+        List<Candidate> candidates = List.of(existingCandidate);
+        List<AppUser> firstCandidates = List.of(newUser);
+        List<AppUser> secondCandidates = List.of(newUser2);
+        List<AppUser> thirdCandidates = List.of(newUser3);
+
+        given(userKeywordRepo.findKeywordIdsByUserId(user.getId())).willReturn(keywordIds);
+        given(candidateRepo.findByUserId(user.getId())).willReturn(candidates);
+        given(userKeywordRepo.findUsersByKeywordIds(keywordIds, List.of(2L, 3L, 1L), Major.건축학과.name())).willReturn(firstCandidates);
+        given(userKeywordRepo.findCategoryNamesByUserId(user.getId())).willReturn(categoryList);
+        given(userKeywordRepo.findUsersByCategoryNames(categoryList, List.of(2L, 3L, 1L, 4L), "건축학과")).willReturn(secondCandidates);
+        given(userKeywordRepo.findRemainUsers(List.of(2L, 3L, 1L, 4L, 5L), "건축학과")).willReturn(thirdCandidates);
+
+        //when
+        List<CandidateDto.Response> result = candidateService.getCandidate(user);
+
+        //then
+        assertThat(result.size()).isEqualTo(3);
+        assertThat(result.get(0).getNickname()).isEqualTo("newUser");
+        assertThat(result.get(1).getNickname()).isEqualTo("newUser2");
+        assertThat(result.get(2).getNickname()).isEqualTo("newUser3");
+    }
+
+    @Test
+    public void getCandidate_2명_미만() {
+        //3순위 2명
+        //given
+        AppUser user = AppUser.builder().id(1L).nickname("user").major(Major.건축학과).build();
+        AppUser existingUser = AppUser.builder().id(2L).nickname("existingUser").major(Major.경영학과).build();
+        AppUser existingUser2 = AppUser.builder().id(3L).nickname("existingUser2").major(Major.경영학과).build();
+        AppUser newUser = AppUser.builder().id(4L).nickname("newUser").major(Major.경영학과).build();
+        AppUser newUser2 = AppUser.builder().id(5L).nickname("newUser2").major(Major.경영학과).build();
+        List<Long> keywordIds = List.of(1L, 2L, 3L);
+        List<String> categoryList = List.of("음식", "운동");
+        Candidate existingCandidate = Candidate.builder().user(user).candidate1(existingUser).candidate2(existingUser2).build();
+        List<Candidate> candidates = List.of(existingCandidate);
+        List<AppUser> emptyList = new ArrayList();
+        List<AppUser> newCandidates = List.of(newUser, newUser2);
+
+
+        given(userKeywordRepo.findKeywordIdsByUserId(user.getId())).willReturn(keywordIds);
+        given(candidateRepo.findByUserId(user.getId())).willReturn(candidates);
+        given(userKeywordRepo.findUsersByKeywordIds(keywordIds, List.of(2L, 3L, 1L), Major.건축학과.name())).willReturn(emptyList);
+        given(userKeywordRepo.findCategoryNamesByUserId(user.getId())).willReturn(categoryList);
+        given(userKeywordRepo.findUsersByCategoryNames(categoryList, List.of(2L, 3L, 1L), "건축학과")).willReturn(emptyList);
+        given(userKeywordRepo.findRemainUsers(List.of(2L, 3L, 1L), "건축학과")).willReturn(newCandidates);
+
+        //when
+        List<CandidateDto.Response> result = candidateService.getCandidate(user);
+
+        //then
+        assertThat(result.size()).isEqualTo(2);
+        assertThat(result.get(0).getNickname()).isEqualTo("newUser");
+        assertThat(result.get(1).getNickname()).isEqualTo("newUser2");
+    }
+}

--- a/backend/src/test/java/skkuchin/service/service/ReviewServiceTest.java
+++ b/backend/src/test/java/skkuchin/service/service/ReviewServiceTest.java
@@ -261,7 +261,7 @@ public class ReviewServiceTest extends MockTest {
         //given
         //AppUser user2 = new AppUser(2L, "test2", "test2", "1234", "test", "0000000001", null, null, null, null, null, null, null, null, null, null);
         AppUser user2 = AppUser.builder()
-                .id(2L).nickname("test2").username("test2").password("1234").email("test").studentId("0000000001")
+                .id(2L).nickname("test2").username("test2").password("1234").email("test").studentId(20)
                 .build();
         Review review1 = new Review(1L, 4.0F, "또 갈래요", "이미지", place, user, null, null);
         Review review2 = new Review(2L, 5.0F, "짱", "img", place, user2, null, null);

--- a/backend/src/test/java/skkuchin/service/service/UserServiceTest.java
+++ b/backend/src/test/java/skkuchin/service/service/UserServiceTest.java
@@ -52,9 +52,9 @@ public class UserServiceTest extends MockTest {
         Collection<Role> roles = new ArrayList<>();
         roles.add(new Role(1L, "ROLE_USER"));
         AppUser userReturnedByRepo = AppUser.builder()
-                .id(1L).nickname("user").username("user111").password("encoderPassword").email("dlaudwns789@gmail.com").studentId("2016310372").major(Major.글로벌경영학과).roles(roles)
+                .id(1L).nickname("user").username("user111").password("encoderPassword").email("dlaudwns789@gmail.com").studentId(16).major(Major.글로벌경영학과).roles(roles)
                 .build();
-        UserDto.SignUpForm signUpForm = new UserDto.SignUpForm("user", "user111", "1234", "1234", "dlaudwns789@gmail.com", "2016310372", Major.글로벌경영학과);
+        UserDto.SignUpForm signUpForm = new UserDto.SignUpForm("user", "user111", "1234", "1234", "dlaudwns789@gmail.com", 16, Major.글로벌경영학과);
 
         given(passwordEncoder.encode(anyString())).willReturn("encoderPassword");
         given(userRepo.save(any())).willReturn(userReturnedByRepo);
@@ -77,7 +77,7 @@ public class UserServiceTest extends MockTest {
         Role role = new Role(1L, "ROLE_USER");
         Collection<Role> roles = new ArrayList<>();
         AppUser user = AppUser.builder()
-                .id(1L).nickname("user").username("user111").password("encoderPassword").email("dlaudwns789@gmail.com").studentId("2016310372").major(Major.글로벌경영학과).image("이미지").mbti(Mbti.ENFP).roles(roles)
+                .id(1L).nickname("user").username("user111").password("encoderPassword").email("dlaudwns789@gmail.com").studentId(16).major(Major.글로벌경영학과).image("이미지").mbti(Mbti.ENFP).roles(roles)
                 .build();
         given(userRepo.findByUsername("user111")).willReturn(user);
         given(roleRepo.findByName("ROLE_USER")).willReturn(role);
@@ -97,7 +97,7 @@ public class UserServiceTest extends MockTest {
         Collection<Role> roles = new ArrayList<>();
         roles.add(role);
         AppUser user = AppUser.builder()
-                .id(1L).nickname("user").username("user111").password("encoderPassword").email("dlaudwns789@gmail.com").studentId("2016310372").major(Major.글로벌경영학과).image("이미지").mbti(Mbti.ENFP).roles(roles)
+                .id(1L).nickname("user").username("user111").password("encoderPassword").email("dlaudwns789@gmail.com").studentId(16).major(Major.글로벌경영학과).image("이미지").mbti(Mbti.ENFP).roles(roles)
                 .build();
         given(userRepo.findByUsername("user111")).willReturn(user);
         given(roleRepo.findByName("ROLE_USER")).willReturn(role);


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! -->
<!-- * are required. -->


#### Notion Task Number *
<!-- Copy the Notion Task Number. e.g. 167220840-P-SYHJ -->
167420784-B-YJ

#### PR Summary *
<!-- A short description of what this pull request does. e.g. 새로운 페이지 진입 시, 스크립트 에러 버그 수정 PR입니다 -->
- AppUser 테이블 명 User로 변경하였습니다.
- studentId 정수 타입으로 변경하였습니다.
- candidate 단위, 통합 테스트 작성하였습니다. 

#### Screenshots / GIFs / Videos
<!-- If the PR includes changes, please include screenshots/GIFs/videos for the team and reviewers. -->
- **AS-IS**

- **TO-BE**


#### Additional Comments
<!-- Add any additional information or comments that would be helpful to the team or reviewers. e.g. 기획서 첨부, 레퍼런스 링크 -->
- 초기 실행 시 테이블 명 변경으로 인한 오류가 발생할 경우
drop table app_user;
drop table app_user_roles;
위의 두 테이블을 삭제하면 됩니다!
- Enum에선 19, 20과 같은 정수를 사용하지 못하는 것 같아 studentId를 int 타입으로 변경했습니다.
UserDto.SignUpForm에서 @Min, @Max로 10학번~23학번까지만 입력 받을 수 있도록 했습니다.
현재는 @Min(value = 10)으로 임의 설정해두었고, 나중에 변경하면 될 것 같습니다!