### PR TITLE
채팅방 목록에서 메시지 받은 시간 표시하는 기능 추가했습니다.

### DIFF
--- a/backend/src/main/java/skkuchin/service/domain/Chat/ChatRoom.java
+++ b/backend/src/main/java/skkuchin/service/domain/Chat/ChatRoom.java
@@ -57,6 +57,9 @@ public class ChatRoom {
 
     private LocalDateTime latestMessageTime;
 
+    private String displayMessageTime;
+
+
     @PrePersist
     public void setDate() {
         LocalDateTime now = LocalDateTime.now();

--- a/backend/src/main/java/skkuchin/service/service/ChatService.java
+++ b/backend/src/main/java/skkuchin/service/service/ChatService.java
@@ -25,7 +25,11 @@ import skkuchin.service.repo.UserRepo;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStreamReader;
+import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.time.Period;
+import java.time.format.DateTimeFormatter;
+import java.time.temporal.ChronoUnit;
 import java.util.*;
 import java.util.stream.Collectors;
 
@@ -165,6 +169,36 @@ public class ChatService {
             if(!chatRooms.get(i).getReceiverRequestStatus().equals(RequestStatus.ACCEPT)){
                 chatRoomRepository.delete(chatRooms.get(i));
             }
+
+        }
+    }
+
+
+    @Scheduled(cron = "* * 0 * * ?") //자정에 display 시간 변경
+    public void setDisplayDateTime() {
+        List<ChatRoom> chatRooms = chatRoomRepository.findAll();
+        LocalDateTime dateTimeNow = LocalDateTime.now();
+        LocalDate dateNow = dateTimeNow.toLocalDate();
+        for (int i = 0; i < chatRooms.size(); i++) {
+            LocalDateTime recordedDateTime = chatRooms.get(i).getLatestMessageTime();
+            LocalDate recordedDate = recordedDateTime.toLocalDate();
+            Period diff = Period.between(recordedDate, dateNow);
+            System.out.println("diff.getDays() = " + diff.getDays());
+            if(diff.getDays() == 1) {
+                chatRooms.get(i).setDisplayMessageTime("어제");
+                chatRoomRepository.save(chatRooms.get(i));
+            }
+            else if(diff.getDays() == 0){
+                chatRooms.get(i).setDisplayMessageTime(recordedDateTime.format(DateTimeFormatter.ofPattern("" +
+                        "HH:mm")));
+                chatRoomRepository.save(chatRooms.get(i));
+            }
+            else if(diff.getDays() > 1){
+                chatRooms.get(i).setDisplayMessageTime(recordedDateTime.format(DateTimeFormatter.ofPattern("" +
+                        "yyyy-MM-dd")));
+                chatRoomRepository.save(chatRooms.get(i));
+            }
+
 
         }
     }

--- a/backend/src/main/java/skkuchin/service/service/ChatService.java
+++ b/backend/src/main/java/skkuchin/service/service/ChatService.java
@@ -92,6 +92,7 @@ public class ChatService {
         System.out.println("chatRoom.getRoomName() = " + chatRoom.getRoomName());
         chatRoom1.setUser1(user);
         chatRoom1.setReceiverRequestStatus(RequestStatus.ACCEPT);
+        chatRoom1.setLatestMessageTime(LocalDateTime.now());
 
         chatRoomRepository.save(chatRoom1);
 
@@ -174,7 +175,8 @@ public class ChatService {
     }
 
 
-    @Scheduled(cron = "* * 0 * * ?") //자정에 display 시간 변경
+    /*@Scheduled(cron = "* * 0 * * ?") //자정에 display 시간 변경*/
+    @Scheduled(cron = "10 * * * * ?") //자정에 display 시간 변경
     public void setDisplayDateTime() {
         List<ChatRoom> chatRooms = chatRoomRepository.findAll();
         LocalDateTime dateTimeNow = LocalDateTime.now();
@@ -183,14 +185,13 @@ public class ChatService {
             LocalDateTime recordedDateTime = chatRooms.get(i).getLatestMessageTime();
             LocalDate recordedDate = recordedDateTime.toLocalDate();
             Period diff = Period.between(recordedDate, dateNow);
-            System.out.println("diff.getDays() = " + diff.getDays());
             if(diff.getDays() == 1) {
                 chatRooms.get(i).setDisplayMessageTime("어제");
                 chatRoomRepository.save(chatRooms.get(i));
             }
             else if(diff.getDays() == 0){
                 chatRooms.get(i).setDisplayMessageTime(recordedDateTime.format(DateTimeFormatter.ofPattern("" +
-                        "HH:mm")));
+                        "a h:mm")));
                 chatRoomRepository.save(chatRooms.get(i));
             }
             else if(diff.getDays() > 1){

--- a/backend/src/main/java/skkuchin/service/service/ChatService.java
+++ b/backend/src/main/java/skkuchin/service/service/ChatService.java
@@ -11,12 +11,9 @@ import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
 import skkuchin.service.api.dto.ChatMessageDto;
 import skkuchin.service.api.dto.ChatRoomDto;
-import skkuchin.service.api.dto.ReviewDto;
 import skkuchin.service.domain.Chat.ChatMessage;
 import skkuchin.service.domain.Chat.ChatRoom;
 import skkuchin.service.domain.Chat.RequestStatus;
-import skkuchin.service.domain.Map.*;
-import skkuchin.service.domain.Matching.Candidate;
 import skkuchin.service.domain.User.AppUser;
 import skkuchin.service.repo.ChatRepo;
 import skkuchin.service.repo.ChatRoomRepo;
@@ -29,7 +26,6 @@ import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.Period;
 import java.time.format.DateTimeFormatter;
-import java.time.temporal.ChronoUnit;
 import java.util.*;
 import java.util.stream.Collectors;
 
@@ -175,8 +171,8 @@ public class ChatService {
     }
 
 
-    /*@Scheduled(cron = "* * 0 * * ?") //자정에 display 시간 변경*/
-    @Scheduled(cron = "10 * * * * ?") //자정에 display 시간 변경
+    @Scheduled(cron = "* * 0 * * ?") //자정에 display 시간 변경*/
+    /*@Scheduled(cron = "10 * * * * ?")*/
     public void setDisplayDateTime() {
         List<ChatRoom> chatRooms = chatRoomRepository.findAll();
         LocalDateTime dateTimeNow = LocalDateTime.now();
@@ -185,16 +181,16 @@ public class ChatService {
             LocalDateTime recordedDateTime = chatRooms.get(i).getLatestMessageTime();
             LocalDate recordedDate = recordedDateTime.toLocalDate();
             Period diff = Period.between(recordedDate, dateNow);
-            if(diff.getDays() == 1) {
+            if(diff.getDays() == 1  && diff.getMonths() ==0 && diff.getYears() ==0) {
                 chatRooms.get(i).setDisplayMessageTime("어제");
                 chatRoomRepository.save(chatRooms.get(i));
             }
-            else if(diff.getDays() == 0){
+            else if(diff.getDays() == 0  && diff.getMonths() ==0 && diff.getYears() ==0){
                 chatRooms.get(i).setDisplayMessageTime(recordedDateTime.format(DateTimeFormatter.ofPattern("" +
                         "a h:mm")));
                 chatRoomRepository.save(chatRooms.get(i));
             }
-            else if(diff.getDays() > 1){
+            else{
                 chatRooms.get(i).setDisplayMessageTime(recordedDateTime.format(DateTimeFormatter.ofPattern("" +
                         "yyyy-MM-dd")));
                 chatRoomRepository.save(chatRooms.get(i));


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! -->
<!-- * are required. -->


#### Notion Task Number *
167449908-B-BJ


#### PR Summary *
카톡 채팅방 기준과 동일합니다
자정에 자동 업데이트 됩니다


**기준**

오늘 수신한 메시지: 오전/오후 구분한 시각
하루 지난 메시지: '어제'
이틀 이상 지난 메시지: "년-월-일

#### Screenshots / GIFs / Videos
<!-- If the PR includes changes, please include screenshots/GIFs/videos for the team and reviewers. -->
- **AS-IS**

- **TO-BE**


#### Additional Comments
<!-- Add any additional information or comments that would be helpful to the team or reviewers. e.g. 기획서 첨부, 레퍼런스 링크 -->

