### PR TITLE
메시지탭 스크롤 이슈 해결/공지탭 헤더 padding 해결/검색 목록 표시 20개 단위 더보기 기능 구현했습니다. 

### DIFF
--- a/frontend/src/components/MessageTab.js
+++ b/frontend/src/components/MessageTab.js
@@ -111,8 +111,8 @@ export default function MessageTab() {
 
   return (
     <Box sx={{ width: '100%' }}>
-      <Box sx={{ borderBottom: 1, borderColor: 'transparent',  backgroundColor:'white',maxWidth:'600px'}}>
-        <Tabs variant="fullWidth" value={value} onChange={handleChange} aria-label="basic tabs example" sx={{position: 'fixed',width:'100%', pt: '15px'}}>
+      <Box sx={{ borderBottom: 1, borderColor: 'transparent',  backgroundColor:'white',maxWidth:'600px', zIndex: '10'}}>
+        <Tabs variant="fullWidth" value={value} onChange={handleChange} aria-label="basic tabs example" sx={{position: 'fixed',width:'100%', pt: '15px', backgroundColor:'white'}}>
           <Tab style={{color:value===0? '#565656':'#BABABA', fontWeight:value===0? '700':'500', fontSize:"15px"}} label="채팅방" {...a11yProps(0)} />
           <Tab style={{color:value===1? '#565656':'#BABABA', fontWeight:value===1? '700':'500', fontSize:"15px"}} label="밥약 신청" {...a11yProps(1)} />
         </Tabs>

--- a/frontend/src/pages/index.js
+++ b/frontend/src/pages/index.js
@@ -19,11 +19,14 @@ import downexplain from '../image/downexplain.jpg';
 import { search_places_discount, search_places_category, search_places_tag, search_places_keyword } from "../actions/place/place";
 
 import dynamic from 'next/dynamic';
+import { width } from "@mui/system";
 
 const Map = dynamic(() => import("../components/Map"));
 const UpperBar = dynamic(() => import("../components/UpperBar"));
 const SearchBox = dynamic(() => import("../components/SearchBox"));
 const TagList = dynamic(() => import("../components/TagList"));
+
+const PLACE_LIMIT = 20; // 초기에 로드할 장소 개수
 
 const list = () => {
     const isSmallScreen = useMediaQuery('(max-width: 375px)');
@@ -79,6 +82,7 @@ const list = () => {
     const tagName = tagsId.map(tag => tag.id);
 
     const [filteredPlace, setFilteredPlace] =useState([]);
+    const [visibleItems, setVisibleItems] = useState(20);
 
     const cardRef = useRef(null);
     const listRef = useRef(null);
@@ -100,7 +104,10 @@ const list = () => {
         }
     }, [searchplace, user, toggle]);
 
-
+    useEffect(()=> {
+        setVisibleItems(20);
+    }, [filteredPlace])
+    
     useEffect(()=>{
         setKeyword('');
         setTags([]);
@@ -369,6 +376,12 @@ const list = () => {
       setOpenDialog(false);
     };
     
+    // 더보기 버튼
+
+    const handleMoreClick = () => {
+        setVisibleItems(visibleItems + 10);
+    };
+
     const TransparentDialog = styled(Dialog)({
         '& .MuiPaper-root': {
           backgroundColor: 'transparent',
@@ -469,7 +482,7 @@ const list = () => {
                     : null
                     }
                     <ul style={{listStyleType: "none", padding: '0px 18px 0px 18px', margin: '0px', width:'100%'}} ref={listRef} >
-                        {filteredPlace? filteredPlace.map((item) => (
+                        {filteredPlace? filteredPlace.slice(0, visibleItems).map((item) => (
                                 <li key={item.id} data={item} style={{borderBottom: '1px solid #D9D9D9'}} onClick={handleLiClick}>
                                     <Link href={`/place?id=${item.id}`} key={item.id}>
                                     <Grid container style={{margin: '15px 0px 0px 0px'}}>
@@ -489,18 +502,6 @@ const list = () => {
                                                             </Typography>
                                                         </Grid>
                                                     }
-                                                    {/* <Grid item style={{padding:'0px 8px 0px 0px', whiteSpace: "normal", display: 'flex' }}>
-                                                        {isSmallScreen && (item.name.length >=13)?
-                                                        <Typography sx={{fontSize: '10px', fontWeight: '500'}} style={{marginTop:'5px'}} color="#a1a1a1" component="div" >
-                                                            {item.detail_category}
-                                                        </Typography>
-                                                        : 
-                                                        <Typography sx={{fontSize: '10px', fontWeight: '500'}} style={{marginTop:'22px'}} color="#a1a1a1" component="div" >
-                                                            {item.detail_category}
-                                                        </Typography>
-                                                        }
-                                                        <Grid item sx={{mt: isSmallScreen && (item.name.length >=13) ? '2px' : '19px', p: '0px 5px'}}>{isFavorite(item.id)}</Grid>
-                                                    </Grid> */}
                                                     <Grid item style={{padding:'0px 0px 0px 0px'}}>
                                                             <Typography sx={{fontSize: '10px', fontWeight: '500'}} style={{marginTop: '22px'}} color="#a1a1a1" component="div" >
                                                                 {item.detail_category}
@@ -590,6 +591,11 @@ const list = () => {
                             </div>
                          }
                         </ul>
+                        {filteredPlace && visibleItems < filteredPlace.length && (
+                            <div style={{width: '100%', textAlign: 'center', padding: '10px'}}>
+                                <button onClick={handleMoreClick} style={{ color: '#fff', backgroundColor: '#FFCE00', fontWeight: 'bold', borderRadius: '20px', border: '0', padding: '12px 15px'}}>더보기</button>
+                            </div>
+                        )}
                     </div>
                 </Card>
                 

--- a/frontend/src/pages/notification.js
+++ b/frontend/src/pages/notification.js
@@ -34,7 +34,7 @@ const NotificationPage = () => {
                     border:'none',
                     maxWidth:'600px'
                 }}>
-                    <Grid container style={{padding:'30px 15px 0px 15px', justifyContent: 'space-between', alignItems: 'center'}}>
+                    <Grid container style={{padding:'30px 15px 0px 15px', justifyContent: 'space-between', alignItems: 'center', backgroundColor:'white'}}>
                         <Grid style={{padding: '5px 10px 0px 0px'}}>
                             <Image src={back} width={12} height={20} name='back' onClick={handleOnclick} layout='fixed' />
                         </Grid>


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! -->
<!-- * are required. -->


#### Notion Task Number *
<!-- Copy the Notion Task Number. e.g. 167220840-P-SYHJ -->
167976414-F-JA
!167864658-HJ-JA

#### PR Summary *
<!-- A short description of what this pull request does. e.g. 새로운 페이지 진입 시, 스크립트 에러 버그 수정 PR입니다 -->


#### Screenshots / GIFs / Videos
<!-- If the PR includes changes, please include screenshots/GIFs/videos for the team and reviewers. -->
- **AS-IS**

- **TO-BE**
![IMG_0078](https://user-images.githubusercontent.com/80195979/227731472-97378584-1896-46d2-b3f0-a766ef64b48f.PNG)

![IMG_0079](https://user-images.githubusercontent.com/80195979/227731468-dd1baa59-68e1-431a-826f-1501b5b17e88.PNG)


https://user-images.githubusercontent.com/80195979/227731574-90673b0c-bc23-48fc-80f6-9651718aa889.mov




#### Additional Comments
<!-- Add any additional information or comments that would be helpful to the team or reviewers. e.g. 기획서 첨부, 레퍼런스 링크 -->

