### PR TITLE
feat(매거진): Top5 식당 조회, 추가, 삭제 기능 추가

### DIFF
--- a/backend/src/main/java/skkuchin/service/api/controller/RankController.java
+++ b/backend/src/main/java/skkuchin/service/api/controller/RankController.java
@@ -1,0 +1,42 @@
+package skkuchin.service.api.controller;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.*;
+import skkuchin.service.dto.CMRespDto;
+import skkuchin.service.dto.RankDto;
+import skkuchin.service.service.RankService;
+
+import java.util.List;
+import java.util.Map;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/rank")
+public class RankController {
+
+    private final RankService rankService;
+
+    @GetMapping("")
+    @PreAuthorize("hasAnyRole('ROLE_ADMIN', 'ROLE_USER')")
+    public ResponseEntity<?> getRank(@RequestBody Map<String, String> campusMap) {
+        List<RankDto.Response> ranks = rankService.getRank(campusMap.get("campus"));
+        return new ResponseEntity<>(new CMRespDto<>(1, "식당 상위 5곳 불러오기 완료", ranks), HttpStatus.OK);
+    }
+
+    @PostMapping("")
+    @PreAuthorize("hasAnyRole('ROLE_ADMIN')")
+    public ResponseEntity<?> addRank() {
+        rankService.addRank();
+        return new ResponseEntity<>(new CMRespDto<>(1, "식당 상위 5곳 추가 완료", null), HttpStatus.CREATED);
+    }
+
+    @DeleteMapping("/{rankId}")
+    @PreAuthorize("hasAnyRole('ROLE_ADMIN')")
+    public ResponseEntity<?> deleteRank(@PathVariable Long rankId) {
+        rankService.deleteRank(rankId);
+        return new ResponseEntity<>(new CMRespDto<>(1, "식당 상위 5곳 삭제 완료", null), HttpStatus.OK);
+    }
+}

--- a/backend/src/main/java/skkuchin/service/domain/Magazine/Ranks.java
+++ b/backend/src/main/java/skkuchin/service/domain/Magazine/Ranks.java
@@ -1,0 +1,45 @@
+package skkuchin.service.domain.Magazine;
+
+import lombok.*;
+import skkuchin.service.domain.Map.Campus;
+import skkuchin.service.domain.Map.Place;
+
+import javax.persistence.*;
+import java.time.LocalDateTime;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+public class Ranks {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    private Place place1;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    private Place place2;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    private Place place3;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    private Place place4;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    private Place place5;
+
+    @Column(nullable = false)
+    @Enumerated(EnumType.STRING)
+    private Campus campus;
+
+    private LocalDateTime date;
+
+    @PrePersist
+    public void setDate() {
+        this.date = LocalDateTime.now();
+    }
+}

--- a/backend/src/main/java/skkuchin/service/dto/RankDto.java
+++ b/backend/src/main/java/skkuchin/service/dto/RankDto.java
@@ -1,0 +1,33 @@
+package skkuchin.service.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import skkuchin.service.domain.Map.Campus;
+import skkuchin.service.domain.Map.Place;
+
+import java.util.Optional;
+
+public class RankDto {
+
+    @Getter
+    @AllArgsConstructor
+    @JsonNaming(value = PropertyNamingStrategies.SnakeCaseStrategy.class)
+    public static class Response {
+        @JsonProperty
+        private Long placeId;
+        @JsonProperty
+        private String placeName;
+        private Campus campus;
+        private double rate;
+
+        public Response(Place place, double rate) {
+            this.placeId = place.getId();
+            this.placeName = place.getName();
+            this.campus = place.getCampus();
+            this.rate = rate;
+        }
+    }
+}

--- a/backend/src/main/java/skkuchin/service/repo/RankRepo.java
+++ b/backend/src/main/java/skkuchin/service/repo/RankRepo.java
@@ -1,0 +1,15 @@
+package skkuchin.service.repo;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import skkuchin.service.domain.Magazine.Ranks;
+import skkuchin.service.domain.Map.Campus;
+
+import java.util.List;
+
+public interface RankRepo extends JpaRepository<Ranks, Long> {
+
+    @Query("SELECT r FROM Ranks r WHERE r.campus = :campus ORDER BY r.date DESC")
+    List<Ranks> findLatestRanksByCampus(@Param("campus") Campus campus);
+}

--- a/backend/src/main/java/skkuchin/service/repo/ReviewRepo.java
+++ b/backend/src/main/java/skkuchin/service/repo/ReviewRepo.java
@@ -2,6 +2,8 @@ package skkuchin.service.repo;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import skkuchin.service.domain.Map.Campus;
 import skkuchin.service.domain.Map.Place;
 import skkuchin.service.domain.Map.Review;
 import skkuchin.service.domain.User.AppUser;
@@ -11,6 +13,16 @@ import java.util.List;
 public interface ReviewRepo extends JpaRepository<Review, Long> {
     List<Review> findByUser(AppUser user);
     List<Review> findByPlace(Place place);
+
+    @Query("SELECT r.place.id, AVG(r.rate) FROM Review r "+
+            "WHERE r.place.campus = :campus "+
+            "GROUP BY r.place ORDER BY COUNT(r) DESC")
+    List<Object[]> findReviewCountPerPlace(@Param("campus") Campus campus);
+
+    @Query("SELECT AVG(r.rate) FROM Review r " +
+            "WHERE r.place.id = :placeId " +
+            "GROUP BY r.place")
+    double findAvgRateOfPlace(@Param("placeId") Long placeId);
 
     @Query("SELECT r FROM Review r WHERE r.user.id = :userId AND r.place.id = :placeId")
     List<Review> findByUserIdAndPlaceId(Long userId, Long placeId);

--- a/backend/src/main/java/skkuchin/service/service/RankService.java
+++ b/backend/src/main/java/skkuchin/service/service/RankService.java
@@ -1,0 +1,78 @@
+package skkuchin.service.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+import skkuchin.service.domain.Magazine.Ranks;
+import skkuchin.service.domain.Map.Campus;
+import skkuchin.service.dto.RankDto;
+import skkuchin.service.repo.PlaceRepo;
+import skkuchin.service.repo.RankRepo;
+import skkuchin.service.repo.ReviewRepo;
+
+import javax.transaction.Transactional;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class RankService {
+    private final RankRepo rankRepo;
+    private final PlaceRepo placeRepo;
+    private final ReviewRepo reviewRepo;
+
+    @Transactional
+    public List<RankDto.Response> getRank(String campus) {
+        Campus cp = campus.equals("명륜") ? Campus.명륜 : Campus.율전;
+        List<Ranks> latestRanks = rankRepo.findLatestRanksByCampus(cp);
+
+        List<RankDto.Response> ranks = new ArrayList<>();
+        if (!latestRanks.isEmpty()) {
+            Ranks latestRank = latestRanks.get(0);
+
+            ranks.add(new RankDto.Response(latestRank.getPlace1(), reviewRepo.findAvgRateOfPlace(latestRank.getPlace1().getId())));
+            ranks.add(new RankDto.Response(latestRank.getPlace2(), reviewRepo.findAvgRateOfPlace(latestRank.getPlace2().getId())));
+            ranks.add(new RankDto.Response(latestRank.getPlace3(), reviewRepo.findAvgRateOfPlace(latestRank.getPlace3().getId())));
+            ranks.add(new RankDto.Response(latestRank.getPlace4(), reviewRepo.findAvgRateOfPlace(latestRank.getPlace4().getId())));
+            ranks.add(new RankDto.Response(latestRank.getPlace5(), reviewRepo.findAvgRateOfPlace(latestRank.getPlace5().getId())));
+        }
+        return ranks;
+    }
+
+    @Scheduled(cron = "0 0 0 * * ?")
+    @Transactional
+    public void addRank() {
+        addToDb("명륜");
+        addToDb("율전");
+
+    }
+
+    @Transactional
+    public void addToDb(String campus) {
+        Campus cp = campus.equals("명륜") ? Campus.명륜 : Campus.율전;
+        List<Object[]> avgRateList = reviewRepo.findReviewCountPerPlace(cp).subList(0, 10);
+        Collections.sort(avgRateList, (o1, o2) -> {
+            Double avgRate1 = (Double) o1[1];
+            Double avgRate2 = (Double) o2[1];
+            return avgRate2.compareTo(avgRate1);
+        });
+
+        Ranks ranks = Ranks.builder()
+                .place1(placeRepo.findById((Long) avgRateList.get(0)[0]).orElseThrow())
+                .place2(placeRepo.findById((Long) avgRateList.get(1)[0]).orElseThrow())
+                .place3(placeRepo.findById((Long) avgRateList.get(2)[0]).orElseThrow())
+                .place4(placeRepo.findById((Long) avgRateList.get(3)[0]).orElseThrow())
+                .place5(placeRepo.findById((Long) avgRateList.get(4)[0]).orElseThrow())
+                .campus(cp)
+                .build();
+        rankRepo.save(ranks);
+    }
+
+    public void deleteRank(Long rankId) {
+        Ranks ranks = rankRepo.findById(rankId).orElseThrow();
+        rankRepo.delete(ranks);
+    }
+}


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! -->
<!-- * are required. -->


#### Notion Task Number *
<!-- Copy the Notion Task Number. e.g. 167220840-P-SYHJ -->


#### PR Summary *
<!-- A short description of what this pull request does. e.g. 새로운 페이지 진입 시, 스크립트 에러 버그 수정 PR입니다 -->
RankService.java > addRank() 메소드가 매일 오전12시마다 호출되면, db에 top5 place 목록이 저장됩니다. (명륜, 율전 각각 1개씩)
(top5 선정 기준: 리뷰 수가 많은 순서대로 정렬하여 10곳을 뽑고, 그 중에서 다시 평점이 높은 순서대로 정렬하여 상위 5곳 반환)

1. [GET] /api/rank
body: {"campus": "명륜"}
매거진 탭 진입 시 요청하는 api로, 가장 최근에 추가된 top5 place 목록을 반환합니다.

3. [POST] /api/rank
관리자만 요청을 보낼 수 있으며, 수동으로 addRank 메소드를 호출하고 싶을 때 사용합니다.

4. [DELETE] /api/rank/{rankId}
관리자만 요청을 보낼 수 있으며, 특정 id를 가진 data를 삭제합니다. 

#### Screenshots / GIFs / Videos
<!-- If the PR includes changes, please include screenshots/GIFs/videos for the team and reviewers. -->
- **AS-IS**

- **TO-BE**


#### Additional Comments
<!-- Add any additional information or comments that would be helpful to the team or reviewers. e.g. 기획서 첨부, 레퍼런스 링크 -->

