### PR TITLE
fix issue: 비로그인 상태 시 전체보기 화면 에러 해결, 그룹 프로필 상세보기 막기, api matchPage 대신 index에서 호출

### DIFF
--- a/frontend/src/components/Matching/Groups.js
+++ b/frontend/src/components/Matching/Groups.js
@@ -3,7 +3,6 @@ import { useEffect, useState } from "react";
 import { Button, Card, Typography, Grid} from '@mui/material';
 import { displayMBTI } from './MBTIList';
 import { useRouter } from 'next/router';
-import GoLogin from "../GoLogin";
 import ErrorPopup from "../Custom/ErrorPopup";
 import { Loading } from "../Loading";
 
@@ -14,7 +13,6 @@ const Groups = () => {
     const myGroupProfiles = useSelector(state => state.groupProfile.myGroupProfiles);
     const requestId = useSelector(state => state.chatRoom.requestId);
     const isAuthenticated = useSelector(state => state.auth.isAuthenticated);
-    const [isLogin, setIsLogin] = useState(false);
 
     const [popupOpen, setPopupOpen] = useState(false);
     const [popupMessage, setPopupMessage] = useState('');
@@ -40,14 +38,19 @@ const Groups = () => {
     }
 
     const handleGroupClick = (id) => {
-        router.push(`/showGroupProfile?id=${id}`);
+        if (isAuthenticated) {
+            router.push(`/showGroupProfile?id=${id}`);
+        } else {
+            setPopupMessage('상세 프로필을 보기 위해서는\n로그인이 필요해요.');
+            setPopupBtnText('로그인하러 가기');
+            setPopupOpen(true);
+        }
     }
 
     const filteredProfiles = myGroupProfiles ? groupProfiles && groupProfiles.filter((group) => !myGroupProfiles.some((myGroup) => myGroup.id == group.id)) : groupProfiles;
     
     return (
         <Grid container sx={{overflowX: 'auto', flexWrap: 'nowrap', p: '0px', m: '0'}}>
-            {isLogin && <GoLogin open={isLogin} onClose={setIsLogin} /> }
             { filteredProfiles && filteredProfiles.length !== 0 ?
                 filteredProfiles.slice(0,5).map((group, index) => (
                         <Card key={index} variant="outlined" sx={{height: 'max-content', width: '242px', borderRadius: '10px', border: '1px solid #E2E2E2', p: '28px 16px', flexShrink: 0, mr: '19px', mb: '10px'}}>

--- a/frontend/src/components/MealPromise/MatchPage.js
+++ b/frontend/src/components/MealPromise/MatchPage.js
@@ -1,15 +1,10 @@
 import React, { useState } from 'react';
 import { Grid, Container, Typography, Button } from '@mui/material';
 import styled from '@emotion/styled';
-import { useDispatch, useSelector } from 'react-redux';
-import { useEffect } from 'react';
 import Friends from '../Matching/Friends';
 import OptionButton from '../Custom/OptionButton';
 import Groups from '../Matching/Groups';
 import { useRouter } from 'next/router';
-import { load_all_group_profile, get_my_group_profile } from '../../actions/groupProfile/groupProfile';
-import { load_candidate } from '../../actions/candidate/candidate';
-import { load_matching_info } from '../../actions/matchingUser/matchingUser';
 
 const MatchContainer = styled.div`
   /* 데스크톱에서 스크롤 바를 숨김 */
@@ -23,22 +18,7 @@ const MatchContainer = styled.div`
 `;
 
 const MatchPage = () => {
-    const dispatch = useDispatch();
     const router = useRouter();
-
-    const isAuthenticated = useSelector(state => state.auth.isAuthenticated);
-    const matchingUser = useSelector(state => state.matchingUser.myMatchingInfo);
-    const myGroupProfiles = useSelector(state => state.groupProfile.myGroupProfiles);
-
-    useEffect(() => {
-        dispatch(load_all_group_profile());
-        dispatch(load_candidate());
-    }, []);
-
-    useEffect(() => {
-        if(isAuthenticated && myGroupProfiles === null) dispatch(get_my_group_profile());
-        if(isAuthenticated && matchingUser === null) dispatch(load_matching_info());
-    }, [isAuthenticated]);
 
     const options = [
         { label: '여럿이서 먹어요', value: '여럿이서 먹어요' },

--- a/frontend/src/pages/index.js
+++ b/frontend/src/pages/index.js
@@ -10,6 +10,10 @@ import mainCharacter from '../image/login_enheng.png';
 import Image from 'next/image';
 import close from '../image/close.png';
 import share from '../image/ios_share.png';
+import { useSelector, useDispatch } from 'react-redux';
+import { load_all_group_profile, get_my_group_profile } from '../actions/groupProfile/groupProfile';
+import { load_candidate } from '../actions/candidate/candidate';
+import { load_matching_info } from '../actions/matchingUser/matchingUser';
 
 const GameContent = () => {
     const games = [
@@ -98,6 +102,8 @@ const GameContent = () => {
 
 const Home = () => {
     const router = useRouter();
+    const dispatch = useDispatch();
+
     const [popup, setPopup] = useState(false);
 
     const handleBtnClick = () => {
@@ -115,6 +121,21 @@ const Home = () => {
             setPopup(true);
         }
     }, [])
+
+    const isAuthenticated = useSelector(state => state.auth.isAuthenticated);
+    const matchingUser = useSelector(state => state.matchingUser.myMatchingInfo);
+    const myGroupProfiles = useSelector(state => state.groupProfile.myGroupProfiles);
+
+    useEffect(() => {
+        dispatch(load_all_group_profile());
+        dispatch(load_candidate());
+    }, []);
+
+    useEffect(() => {
+        if(isAuthenticated && myGroupProfiles === null) dispatch(get_my_group_profile());
+        if(isAuthenticated && matchingUser === null) dispatch(load_matching_info());
+    }, [isAuthenticated]);
+
     return (
         <HomeContainer>
             <ThemeProvider theme={theme}>

--- a/frontend/src/pages/selectMyGroupProfile.js
+++ b/frontend/src/pages/selectMyGroupProfile.js
@@ -55,7 +55,7 @@ const selectMyGroupProfile = () => {
                 <CssBaseline />
                 <Header title="" icon='close'/>
 
-                <div style={{padding: '63px 24px 0', fontSize: '16px', flex: 1}}>
+                <div style={{padding: '51px 24px 0', fontSize: '16px', flex: 1}}>
                     <Typography sx={{fontWeight: 'bold', m: '50px 0', p: '25px 0', textAlign: 'center'}}>
                         [{localStorage.getItem('candidateName')}]에게 밥약을 신청할<br />
                         나의 그룹을 선택해주세요.

--- a/frontend/src/pages/showAllGroupLists.js
+++ b/frontend/src/pages/showAllGroupLists.js
@@ -30,10 +30,18 @@ const ShowAllGroupLists = () => {
     const filteredProfiles =
         selectedFilter === '전체'
         ? groups
-        : groups.filter((group) => group.gender == selectedFilter);
+        : user
+            ? groups.filter((group) => group.gender === selectedFilter && !myGroupProfiles.some((myGroup) => myGroup.id == group.id))
+            : groups.filter((group) => group.gender === selectedFilter);
 
     const handleGroupClick = (id) => {
-        router.push(`/showGroupProfile?id=${id}`);
+        if(isAuthenticated) {
+            router.push(`/showGroupProfile?id=${id}`);
+        } else {
+            setPopupMessage('상세 프로필을 보기 위해서는\n로그인이 필요해요.');
+            setPopupBtnText('로그인하러 가기');
+            setPopupOpen(true);
+        }
     }
 
     const handleBackClick = () => {
@@ -80,7 +88,6 @@ const ShowAllGroupLists = () => {
             <div style={{ overflow: 'scroll', padding: '12px 24px', marginTop: '109px' }}>
                 {filteredProfiles && filteredProfiles.length !== 0 ? (
                     filteredProfiles
-                        .filter((group) => !myGroupProfiles.some((myGroup) => myGroup.id == group.id))
                         .slice(0, displayCount)
                         .map((group, index) => (
                             <div style={{ marginBottom: '12px' }} key={index} onClick={() => handleGroupClick(group.id)}>

--- a/frontend/src/pages/showAllTwoLists.js
+++ b/frontend/src/pages/showAllTwoLists.js
@@ -22,11 +22,18 @@ const showAllTwoLists = () => {
 
     const filterOptions = ['전체', '명륜', '율전'];
 
+    // const filteredProfiles =
+    //     selectedFilter === '전체'
+    //     ? candidate && candidate.filter((candidate) => candidate.id !== user.id)
+    //     : candidate && candidate.filter((candidate) => candidate.campus === selectedFilter && candidate.id !== user.id);
+
     const filteredProfiles =
         selectedFilter === '전체'
-        ? candidate && candidate.filter((candidate) => candidate.id !== user.id)
-        : candidate && candidate.filter((candidate) => candidate.campus === selectedFilter && candidate.id !== user.id);
-
+            ? candidate && candidate.filter((candidate) => candidate.id !== user?.id)
+            : user
+                ? candidate && candidate.filter((candidate) => candidate.campus === selectedFilter && candidate.id !== user.id)
+                : candidate && candidate.filter((candidate) => candidate.campus === selectedFilter);
+    
     const handleBackClick = () => {
         router.push('/mealPromise');
     }

--- a/frontend/src/pages/showFriendProfile.js
+++ b/frontend/src/pages/showFriendProfile.js
@@ -5,12 +5,13 @@ import theme from '../theme/theme';
 import { CssBaseline, ThemeProvider } from '@mui/material';
 import { Loading } from '../components/Loading';
 import { load_other_matching_info, clear_matching } from '../actions/matchingUser/matchingUser';
-import { useDispatch } from 'react-redux';
+import { useDispatch, useSelector } from 'react-redux';
 
 const showFriendProfile = () => {
     const dispatch = useDispatch();
 
     const [isLoading, setIsLoading] = useState(true);
+    const user = useSelector(state => state.auth.user);
     const [candidate, setCandidate] = useState(null);
 
     useEffect(() => {
@@ -19,7 +20,7 @@ const showFriendProfile = () => {
     }, []);
 
     useEffect(() => {
-        if(candidate) {
+        if(candidate && user) {
             clear_matching();
             dispatch(load_other_matching_info(candidate.id, ([result, message]) => {
                 if(result) {


### PR DESCRIPTION
개인 프로필 상세 조회 하려면 GET ${API_URL}/api/matching/user/${id} api를 호출해야 하는데, 헤더에 authorization을 받고 있습니다.
따라서 비로그인 상태에서는 개인 프로필 상세 조회가 불가한 상황입니다 ㅜ ㅜ 
authorization 없이도 개인 프로필 정보 받아올 수 있도록 api 수정해주실 수 있나요? 

*actions > matchingUser > matchingUser > load_other_matching_info 부분입니다
@myungjunlee 